### PR TITLE
Split fetch methode into multiple files if desired

### DIFF
--- a/templates/default/README.md
+++ b/templates/default/README.md
@@ -23,12 +23,20 @@ So you want to tussle with Methode huh? You are brave. Fill out `config.js` like
 ```
 	...
 	"methode": {
-		"story": [{"path": "path/to/xml"}]
+		"story": [
+			{
+				"path": "path/to/xml"
+			},
+			{
+				"path": "path/to/another/xml",
+				"filename": "name-of-hbs-file"
+			}
+		]
 	}
 
 ```
 
-This pipes text and images from Methode into methode.hbs and downloads the images locally.
+This pipes text and images from Methode into a handlebar file and downloads the images locally. Objects with a `filename` string will have their Methode text and images written to a file with a corresponding name; using the example above would result in name-of-hbs-file.hbs. Objects without a `filename` will be written to methode.hbs.
 
 To insert a graphic partial inside methode, simply create a new p tag and use the convention `{{graphic:test}}`. Make sure you have the partial `src/html/partials/graphic/test.hbs`.
 

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -37,6 +37,7 @@
     "gulp-zip": "3.2.0",
     "jimp": "0.2.24",
     "json-loader": "0.5.4",
+    "lodash": "^4.17.4",
     "promis": "1.1.4",
     "request": "2.72.0",
     "require-dir": "0.3.0",

--- a/templates/multipage/server.js
+++ b/templates/multipage/server.js
@@ -6,6 +6,13 @@ var app = express();
 var router = express.Router();
 
 app.use(express.static('dist/dev'));
+
+app.get('/**/assets/**/*.*', function(req, res) {
+    const srcpath = req.path.split('/assets')
+    const file = srcpath[(srcpath.length - 1)]
+    res.sendFile('./dist/dev/assets' + file , { root: __dirname });
+});
+
 app.get('/**/*.*', function(req, res) {
     const srcpath = req.path.split('/')
     const file = srcpath[(srcpath.length - 1)]


### PR DESCRIPTION
Adding a `filename` string to a methode story object will pipe the text and images into that file. Having multiple stories with the same `filename` will pipe those all into the same file. 

Usage:

```
	...
	"methode": {
		"story": [
			{
				"path": "path/to/xml"
			},
			{
				"path": "path/to/another/xml",
				"filename": "name-of-hbs-file"
			}
		]
	}

```