### PR TITLE
Adding progressBar meta option

### DIFF
--- a/templates/default/src/html/partials/base/base-meta.hbs
+++ b/templates/default/src/html/partials/base/base-meta.hbs
@@ -19,6 +19,7 @@
 <meta property='author' content='{{meta.author}}' />
 <meta property='meter' content='{{meta.meter}}' />
 <meta property='socialConnect' content='{{meta.socialConnect}}' /><% } %>
+<meta property='progressBar' content='{{meta.progressBar}}' /><% } %>
 
 <meta property='og:city' content='Boston' />
 <meta property='og:state' content='MA' />


### PR DESCRIPTION
This allows us to prevent the paywall progress bar from showing.

@kowall116 - can you double check this? We were not outputting the `progressBar` meta option to the DOM, and so `business.js` was not removing the progress bar at all.